### PR TITLE
make `mtry` interface consistent with other parsnip wrappers

### DIFF
--- a/R/0_imports.R
+++ b/R/0_imports.R
@@ -32,7 +32,7 @@ generics::tunable
 utils::globalVariables(
   c(
     ".pred_1", ".pred_2", ".pred_class", ".row_number", "object", "new_data", "name",
-    ".pred", "(Intercept)", "committee", "rule", "trials",
+    ".pred", "(Intercept)", "committee", "rule", "trials", "terms",
     "column", "conds", "cover", "coverage", "error", "esterr", "estimate", "feature", "hival",
     "less_than", "level", "loval", "num_conditions", "rule_comp", "rule_id", "rule_num",
     "split_id", "split_value", "statistic", "term", "value", "lift", "ok", "trial"

--- a/R/rule_fit.R
+++ b/R/rule_fit.R
@@ -65,13 +65,13 @@ process_mtry <- function(colsample_bytree, counts, n_predictors, is_missing) {
 
   if ((colsample_bytree < 1 & counts) | (colsample_bytree > 1 & !counts)) {
     rlang::abort(
-      glue::glue(
-        "The supplied argument `mtry = {colsample_bytree}` must be ",
-        "{ineq} than or equal to 1. \n\n`mtry` is currently being interpreted ",
-        "as a {interp} rather than a {opp}. Supply `counts = {!counts}` to ",
-        "`set_engine` to supply this argument as a {opp} rather than ",
+      paste0(
+        "The supplied argument `mtry = ", colsample_bytree, "` must be ",
+        ineq, " than or equal to 1. \n\n`mtry` is currently being interpreted ",
+        "as a ", interp, " rather than a ", opp, ". Supply `counts = ", !counts,
+        "` to `set_engine()` to supply this argument as a ", opp, " rather than ",
         # TODO: add a section to the linked parsnip docs on mtry vs mtry_prop
-        "a {interp}. \n\nSee `?details_rule_fit_xrf` for more details."
+        "a ", interp, ". \n\nSee `?details_rule_fit_xrf` for more details."
       ),
       call = NULL
     )
@@ -80,7 +80,7 @@ process_mtry <- function(colsample_bytree, counts, n_predictors, is_missing) {
   if (rlang::is_call(colsample_bytree)) {
     if (rlang::call_name(colsample_bytree) == "tune") {
       rlang::abort(
-        glue::glue(
+        paste0(
           "The supplied `mtry` parameter is a call to `tune`. Did you forget ",
           "to optimize hyperparameters with a tuning function like `tune::tune_grid`?"
         ),

--- a/man/rules-internal.Rd
+++ b/man/rules-internal.Rd
@@ -35,6 +35,7 @@ xrf_fit(
   gamma = 0,
   subsample = 1,
   lambda = 0.1,
+  counts = TRUE,
   ...
 )
 

--- a/tests/testthat/_snaps/rule-fit-regression.md
+++ b/tests/testthat/_snaps/rule-fit-regression.md
@@ -1,0 +1,32 @@
+# rule_fit handles mtry vs mtry_prop gracefully
+
+    The supplied argument `mtry = 0.5` must be greater than or equal to 1. 
+    
+    `mtry` is currently being interpreted as a count rather than a proportion. Supply `counts = FALSE` to `set_engine` to supply this argument as a proportion rather than a count. 
+    
+    See `?details_rule_fit_xrf` for more details.
+
+---
+
+    The supplied argument `mtry = 3` must be less than or equal to 1. 
+    
+    `mtry` is currently being interpreted as a proportion rather than a count. Supply `counts = TRUE` to `set_engine` to supply this argument as a count rather than a proportion. 
+    
+    See `?details_rule_fit_xrf` for more details.
+
+---
+
+    Code
+      pars_fit_8 <- rule_fit(mtry = 0.5, trees = 5) %>% set_engine("xrf",
+        colsample_bytree = 0.5) %>% set_mode("regression") %>% fit(Sale_Price ~
+        Neighborhood + Longitude + Latitude + Gr_Liv_Area + Central_Air, data = ames_data$
+        ames)
+    Warning <rlang_warning>
+      The following arguments cannot be manually modified and were removed: colsample_bytree.
+    Error <rlang_error>
+      The supplied argument `mtry = 0.5` must be greater than or equal to 1. 
+      
+      `mtry` is currently being interpreted as a count rather than a proportion. Supply `counts = FALSE` to `set_engine` to supply this argument as a proportion rather than a count. 
+      
+      See `?details_rule_fit_xrf` for more details.
+

--- a/tests/testthat/_snaps/rule-fit-regression.md
+++ b/tests/testthat/_snaps/rule-fit-regression.md
@@ -2,7 +2,7 @@
 
     The supplied argument `mtry = 0.5` must be greater than or equal to 1. 
     
-    `mtry` is currently being interpreted as a count rather than a proportion. Supply `counts = FALSE` to `set_engine` to supply this argument as a proportion rather than a count. 
+    `mtry` is currently being interpreted as a count rather than a proportion. Supply `counts = FALSE` to `set_engine()` to supply this argument as a proportion rather than a count. 
     
     See `?details_rule_fit_xrf` for more details.
 
@@ -10,7 +10,7 @@
 
     The supplied argument `mtry = 3` must be less than or equal to 1. 
     
-    `mtry` is currently being interpreted as a proportion rather than a count. Supply `counts = TRUE` to `set_engine` to supply this argument as a count rather than a proportion. 
+    `mtry` is currently being interpreted as a proportion rather than a count. Supply `counts = TRUE` to `set_engine()` to supply this argument as a count rather than a proportion. 
     
     See `?details_rule_fit_xrf` for more details.
 
@@ -26,7 +26,7 @@
     Error <rlang_error>
       The supplied argument `mtry = 0.5` must be greater than or equal to 1. 
       
-      `mtry` is currently being interpreted as a count rather than a proportion. Supply `counts = FALSE` to `set_engine` to supply this argument as a proportion rather than a count. 
+      `mtry` is currently being interpreted as a count rather than a proportion. Supply `counts = FALSE` to `set_engine()` to supply this argument as a proportion rather than a count. 
       
       See `?details_rule_fit_xrf` for more details.
 

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -62,9 +62,9 @@ make_ames_data <- function() {
 
   ames <-
     ames %>%
-    mutate(
-      Sale_Price = log10(ames$Sale_Price),
-      Gr_Liv_Area = log10(ames$Gr_Liv_Area)
+    dplyr::mutate(
+      Sale_Price = log10(Sale_Price),
+      Gr_Liv_Area = log10(Gr_Liv_Area)
     )
 
   list(ames = ames)
@@ -91,4 +91,8 @@ make_hpc_data <- function(x) {
 
   list(hpc_mod = hpc_mod, hpc_pred = hpc_pred, hpc_data = hpc_data,
        vals = vals, lvls = lvls)
+}
+
+expect_error_free <- function(...) {
+  testthat::expect_error(..., regexp = NA)
 }

--- a/tests/testthat/test-rule-fit-regression.R
+++ b/tests/testthat/test-rule-fit-regression.R
@@ -184,7 +184,7 @@ test_that("rule_fit handles mtry vs mtry_prop gracefully", {
   # supply mtry = 1 (edge cases)
   expect_error_free({
     pars_fit_2 <-
-      rule_fit(mtry = 1, trees = 5) %>%
+      rule_fit(mtry = 5, trees = 5) %>%
       set_engine("xrf", counts = TRUE) %>%
       set_mode("regression") %>%
       fit(
@@ -196,7 +196,7 @@ test_that("rule_fit handles mtry vs mtry_prop gracefully", {
 
   expect_equal(
     extract_fit_engine(pars_fit_2)$xgb$params$colsample_bytree,
-    1 / 5
+    1
   )
 
   expect_error_free({
@@ -219,7 +219,7 @@ test_that("rule_fit handles mtry vs mtry_prop gracefully", {
   # supply a count (with default counts = TRUE)
   expect_error_free({
     pars_fit_4 <-
-      rule_fit(mtry = 3, trees = 5) %>%
+      rule_fit(mtry = 5, trees = 5) %>%
       set_engine("xrf") %>%
       set_mode("regression") %>%
       fit(
@@ -231,7 +231,7 @@ test_that("rule_fit handles mtry vs mtry_prop gracefully", {
 
   expect_equal(
     extract_fit_engine(pars_fit_4)$xgb$params$colsample_bytree,
-    3 / 5
+    1
   )
 
   # supply a proportion when count expected
@@ -294,7 +294,7 @@ test_that("rule_fit handles mtry vs mtry_prop gracefully", {
 
   expect_warning({
     pars_fit_9 <-
-      rule_fit(mtry = 2, trees = 5) %>%
+      rule_fit(mtry = 5, trees = 5) %>%
       set_engine("xrf", colsample_bytree = .5) %>%
       set_mode("regression") %>%
       fit(
@@ -307,6 +307,6 @@ test_that("rule_fit handles mtry vs mtry_prop gracefully", {
 
   expect_equal(
     extract_fit_engine(pars_fit_9)$xgb$params$colsample_bytree,
-    2 / 5
+    1
   )
 })

--- a/tests/testthat/test-rule-fit-regression.R
+++ b/tests/testthat/test-rule-fit-regression.R
@@ -156,3 +156,157 @@ test_that("tidy method - regression", {
     sort(unique(xrf_col_res$rule_id))
   )
 })
+
+test_that("rule_fit handles mtry vs mtry_prop gracefully", {
+  skip_on_cran()
+  skip_if_not_installed("xrf")
+
+  ames_data <- make_ames_data()
+
+  # supply no mtry
+  expect_error_free({
+    pars_fit_1 <-
+      rule_fit(trees = 5) %>%
+      set_engine("xrf") %>%
+      set_mode("regression") %>%
+      fit(
+        Sale_Price ~ Neighborhood + Longitude + Latitude +
+          Gr_Liv_Area + Central_Air,
+        data = ames_data$ames
+      )
+  })
+
+  expect_equal(
+    extract_fit_engine(pars_fit_1)$xgb$params$colsample_bytree,
+    1
+  )
+
+  # supply mtry = 1 (edge cases)
+  expect_error_free({
+    pars_fit_2 <-
+      rule_fit(mtry = 1, trees = 5) %>%
+      set_engine("xrf", counts = TRUE) %>%
+      set_mode("regression") %>%
+      fit(
+        Sale_Price ~ Neighborhood + Longitude + Latitude +
+          Gr_Liv_Area + Central_Air,
+        data = ames_data$ames
+      )
+  })
+
+  expect_equal(
+    extract_fit_engine(pars_fit_2)$xgb$params$colsample_bytree,
+    1 / 5
+  )
+
+  expect_error_free({
+    pars_fit_3 <-
+      rule_fit(mtry = 1, trees = 5) %>%
+      set_engine("xrf", counts = FALSE) %>%
+      set_mode("regression") %>%
+      fit(
+        Sale_Price ~ Neighborhood + Longitude + Latitude +
+          Gr_Liv_Area + Central_Air,
+        data = ames_data$ames
+      )
+  })
+
+  expect_equal(
+    extract_fit_engine(pars_fit_3)$xgb$params$colsample_bytree,
+    1
+  )
+
+  # supply a count (with default counts = TRUE)
+  expect_error_free({
+    pars_fit_4 <-
+      rule_fit(mtry = 3, trees = 5) %>%
+      set_engine("xrf") %>%
+      set_mode("regression") %>%
+      fit(
+        Sale_Price ~ Neighborhood + Longitude + Latitude +
+            Gr_Liv_Area + Central_Air,
+        data = ames_data$ames
+      )
+  })
+
+  expect_equal(
+    extract_fit_engine(pars_fit_4)$xgb$params$colsample_bytree,
+    3 / 5
+  )
+
+  # supply a proportion when count expected
+  expect_snapshot_error({
+    pars_fit_5 <-
+      rule_fit(mtry = .5, trees = 5) %>%
+      set_engine("xrf") %>%
+      set_mode("regression") %>%
+      fit(
+        Sale_Price ~ Neighborhood + Longitude + Latitude +
+          Gr_Liv_Area + Central_Air,
+        data = ames_data$ames
+      )
+  })
+
+  # supply a count when proportion expected
+  expect_snapshot_error({
+    pars_fit_6 <-
+      rule_fit(mtry = 3, trees = 5) %>%
+      set_engine("xrf", counts = FALSE) %>%
+      set_mode("regression") %>%
+      fit(
+        Sale_Price ~ Neighborhood + Longitude + Latitude +
+          Gr_Liv_Area + Central_Air,
+        data = ames_data$ames
+      )
+  })
+
+  expect_warning({
+    pars_fit_7 <-
+      rule_fit(trees = 5) %>%
+      set_engine("xrf", colsample_bytree = .5) %>%
+      set_mode("regression") %>%
+      fit(
+        Sale_Price ~ Neighborhood + Longitude + Latitude +
+          Gr_Liv_Area + Central_Air,
+        data = ames_data$ames
+      )},
+    "manually modified and were removed: colsample_bytree."
+  )
+
+  expect_equal(
+    extract_fit_engine(pars_fit_7)$xgb$params$colsample_bytree,
+    1
+  )
+
+  # supply both feature fraction and mtry
+  expect_snapshot({
+    pars_fit_8 <-
+      rule_fit(mtry = .5, trees = 5) %>%
+      set_engine("xrf", colsample_bytree = .5) %>%
+      set_mode("regression") %>%
+      fit(
+        Sale_Price ~ Neighborhood + Longitude + Latitude +
+          Gr_Liv_Area + Central_Air,
+        data = ames_data$ames
+      )},
+    error = TRUE
+  )
+
+  expect_warning({
+    pars_fit_9 <-
+      rule_fit(mtry = 2, trees = 5) %>%
+      set_engine("xrf", colsample_bytree = .5) %>%
+      set_mode("regression") %>%
+      fit(
+        Sale_Price ~ Neighborhood + Longitude + Latitude +
+          Gr_Liv_Area + Central_Air,
+        data = ames_data$ames
+      )},
+    "manually modified and were removed: colsample_bytree."
+  )
+
+  expect_equal(
+    extract_fit_engine(pars_fit_9)$xgb$params$colsample_bytree,
+    2 / 5
+  )
+})


### PR DESCRIPTION
Introduces a `counts` argument to `xrf_fit` and processes `mtry` as described here:

https://github.com/tidymodels/dials/blob/c15aac7ddefb78c88c378d3d4158c204e999c602/R/param_mtry_prop.R#L23-L28

This follows bonsai's implementation closely, except that there's some trickiness with the interface to predictors.

To-do: add a docs section in the parsnip `details` doc for each of parsnip's xgboost, bonsai's lightgbm, and this wrapper.