### PR TITLE
use parsnip machinery to determine `n_predictors`

### DIFF
--- a/R/rule_fit.R
+++ b/R/rule_fit.R
@@ -18,7 +18,7 @@ xrf_fit <-
       process_mtry(
         colsample_bytree = colsample_bytree,
         counts = counts,
-        n_predictors = length(attr(terms(formula), "term.labels")),
+        n_predictors = parsnip::max_mtry_formula(Inf, formula, data),
         is_missing = missing(colsample_bytree)
       )
     args <- list(


### PR DESCRIPTION
Following up on my self-review from #56, I came across some code this morning that seems more principled. :)

```
> parsnip::max_mtry_formula(Inf, mpg ~ ., mtcars)
[1] 10
```