### PR TITLE
Bug family quosure

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * The `tidy()` method for RuleFit models was not using the penalty value. This is corrected and a single penalty value is required for using the function. (#66)
 
+* Fixed bug where predict sometimes didn't work for xrf models.
+
 # rules 1.0.0
 
 * `tidy()` method for Cubist models now has an option for how many committees to tidy. 

--- a/R/rule_fit.R
+++ b/R/rule_fit.R
@@ -171,7 +171,6 @@ get_levels <- function(formula, data) {
   res
 }
 
-
 #' @export
 #' @keywords internal
 #' @rdname rules-internal
@@ -179,10 +178,11 @@ xrf_pred <- function(object, new_data, lambda = object$fit$lambda, type, ...) {
   lambda <- sort(lambda)
 
   res <- predict(object$fit, new_data, lambda = lambda, type = "response")
+  family <- rlang::as_name(object$fit$family)
   if (type != "prob") {
-    res <- organize_xrf_multi_pred(res, object, lambda, object$fit$family)
+    res <- organize_xrf_multi_pred(res, object, lambda, family)
   } else {
-    res <- organize_xrf_multi_prob(res, object, lambda, object$fit$family)
+    res <- organize_xrf_multi_prob(res, object, lambda, family)
   }
   res
 }


### PR DESCRIPTION
This PR aims to fix bug discovered in https://community.rstudio.com/t/predict-from-rule-fit-model-error-in-match-x-table-nomatch-0l/157259

``` r
set.seed(13)
options(scipen=999)

library(tidymodels)
library(rules)
#> 
#> Attaching package: 'rules'
#> The following object is masked from 'package:dials':
#> 
#>     max_rules
library(xrf)

data.mtcars <- mtcars

data.mtcars.split <- initial_split(data.mtcars,
                                   prop = 0.9)

data.mtcars.train <- training(data.mtcars.split)
data.mtcars.test <- testing(data.mtcars.split)

spec_untuned_rule <- rule_fit() %>%
  set_engine("xrf", family = "gaussian") %>%
  set_mode("regression")

rec_untuned_rule <- recipe(mpg ~ ., data = data.mtcars.train) %>%
  step_center(all_predictors()) %>% # mean zero
  step_scale(all_predictors()) # standard deviation one

workflow_untuned_rule <- workflow() %>%
  add_recipe(rec_untuned_rule) %>% 
  add_model(spec_untuned_rule)

system.time(model_rule <- fit(workflow_untuned_rule,
                              data = data.mtcars.train))
#>    user  system elapsed 
#>   5.812   0.064   5.879

predictions_train_rule <- predict(model_rule,
                                  data.mtcars.train) %>%
  bind_cols(data.mtcars.train) # combine w/ original dataset

predictions_train_rule
#> # A tibble: 28 × 12
#>    .pred   mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
#>  * <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#>  1  13.8  13.3     8 350     245  3.73  3.84  15.4     0     0     3     4
#>  2  22.8  22.8     4 108      93  3.85  2.32  18.6     1     1     4     1
#>  3  18.8  18.7     8 360     175  3.15  3.44  17.0     0     0     3     2
#>  4  19.2  19.2     6 168.    123  3.92  3.44  18.3     1     0     4     4
#>  5  16.8  17.3     8 276.    180  3.07  3.73  17.6     0     0     3     3
#>  6  18.1  18.1     6 225     105  2.76  3.46  20.2     1     0     3     1
#>  7  10.6  10.4     8 460     215  3     5.42  17.8     0     0     3     4
#>  8  15.8  15.5     8 318     150  2.76  3.52  16.9     0     0     3     2
#>  9  21.0  21.4     6 258     110  3.08  3.22  19.4     1     0     3     1
#> 10  30.3  30.4     4  75.7    52  4.93  1.62  18.5     1     1     4     2
#> # … with 18 more rows
```

<sup>Created on 2023-01-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>