### PR TITLE
Standardize Posit name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-0679-1945")),
     person("Max", "Kuhn", , "max@posit.co", role = c("aut"),
            comment = c(ORCID = "0000-0003-2402-136X")),
-    person("Posit Software PBC", role = c("cph", "fnd"))
+    person("Posit Software, PBC", role = c("cph", "fnd"))
   )
 Description: Bindings for additional models for use with the 'parsnip'
     package.  Models include prediction rule ensembles (Friedman and


### PR DESCRIPTION
I scraped CRAN to find companies that fund R packages, and noticed that Posit is credited 6 different ways (9 if you include RStudio/RStudio PBC/RStudio, PBC). I'm submitting PRs with the official "Posit Software, PBC" name on the few Posit varieties to nip it in the bud.