### PR TITLE
Remove penalty argument in xrf

### DIFF
--- a/tests/testthat/test-rule-fit-binomial.R
+++ b/tests/testthat/test-rule-fit-binomial.R
@@ -11,7 +11,7 @@ test_that("formula method", {
       Class ~ .,
       data = ad_data$ad_mod,
       family = "binomial",
-      xgb_control = list(nrounds = 3, min_child_weight = 3, penalty = 1),
+      xgb_control = list(nrounds = 3, min_child_weight = 3),
       verbose = 0
     )
   rf_pred_exp <- predict(rf_fit_exp, ad_data$ad_pred, lambda = 1)[, 1]
@@ -118,7 +118,7 @@ test_that("non-formula method", {
       Class ~ .,
       data = ad_data$ad_mod,
       family = "binomial",
-      xgb_control = list(nrounds = 3, min_child_weight = 3, penalty = 1),
+      xgb_control = list(nrounds = 3, min_child_weight = 3),
       verbose = 0
     )
   rf_pred_exp <- predict(rf_fit_exp, ad_data$ad_pred, lambda = 1)[, 1]

--- a/tests/testthat/test-rule-fit-multinomial.R
+++ b/tests/testthat/test-rule-fit-multinomial.R
@@ -14,7 +14,6 @@ test_that("formula method", {
       xgb_control = list(
         nrounds = 3,
         min_child_weight = 3,
-        penalty = 1,
         num_class = 4
       ),
       verbose = 0
@@ -127,7 +126,6 @@ test_that("non-formula method", {
       xgb_control = list(
         nrounds = 3,
         min_child_weight = 3,
-        penalty = 1,
         num_class = 4
       ),
       verbose = 0

--- a/tests/testthat/test-rule-fit-regression.R
+++ b/tests/testthat/test-rule-fit-regression.R
@@ -11,7 +11,7 @@ test_that("formula method", {
       ridership ~ .,
       data = chi_data$chi_mod,
       family = "gaussian",
-      xgb_control = list(nrounds = 3, min_child_weight = 3, penalty = 1),
+      xgb_control = list(nrounds = 3, min_child_weight = 3),
       verbose = 0
     )
   rf_pred_exp <- predict(rf_fit_exp, chi_data$chi_pred, lambda = 1)[, 1]
@@ -72,7 +72,7 @@ test_that("non-formula method", {
       ridership ~ .,
       data = chi_data$chi_mod,
       family = "gaussian",
-      xgb_control = list(nrounds = 3, min_child_weight = 3, penalty = 1),
+      xgb_control = list(nrounds = 3, min_child_weight = 3),
       verbose = 0
     )
   rf_pred_exp <- predict(rf_fit_exp, chi_data$chi_pred, lambda = 1)[, 1]


### PR DESCRIPTION
- Fixes #81 

Note: The `penalty` argument only causes issues with `xrf`. In all other cases the argument was left there. Tests now show no warnings. 