### PR TITLE
Pass objective as passible engine argument for rule_fit()

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -26,8 +26,6 @@ jobs:
           - {os: macos-latest,   r: 'release'}
 
           - {os: windows-latest, r: 'release'}
-          # use 4.0 or 4.1 to check with rtools40's older compiler
-          - {os: windows-latest, r: 'oldrel-4'}
 
           - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,  r: 'release'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,8 +33,6 @@ jobs:
           - {os: ubuntu-latest,  r: 'release'}
           - {os: ubuntu-latest,  r: 'oldrel-1'}
           - {os: ubuntu-latest,  r: 'oldrel-2'}
-          - {os: ubuntu-latest,  r: 'oldrel-3'}
-          - {os: ubuntu-latest,  r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,4 +49,4 @@ Config/usethis/last-upkeep: 2025-04-24
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/rule_fit.R
+++ b/R/rule_fit.R
@@ -18,6 +18,7 @@ xrf_fit <-
     counts = TRUE,
     event_level = c("first", "second"),
     lambda = 0.1,
+    objective = NULL,
     ...
   ) {
     converted <-
@@ -40,7 +41,7 @@ xrf_fit <-
         subsample = subsample,
         validation = validation,
         early_stop = early_stop,
-        objective = NULL,
+        objective = objective,
         counts = counts,
         event_level = event_level
       )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -9,6 +9,7 @@ PBC
 PSOCK
 Popescu
 Quinlan
+ROR
 RStudio
 RuleFit
 doi

--- a/man/rules-internal.Rd
+++ b/man/rules-internal.Rd
@@ -40,6 +40,7 @@ xrf_fit(
   counts = TRUE,
   event_level = c("first", "second"),
   lambda = 0.1,
+  objective = NULL,
   ...
 )
 

--- a/man/rules-package.Rd
+++ b/man/rules-package.Rd
@@ -29,7 +29,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item Posit Software, PBC (03wc8by49) [copyright holder, funder]
+  \item Posit Software, PBC (\href{https://ror.org/03wc8by49}{ROR}) [copyright holder, funder]
 }
 
 }

--- a/man/tidy.cubist.Rd
+++ b/man/tidy.cubist.Rd
@@ -159,17 +159,20 @@ xrf_rule_res <- tidy(xrf_reg_fit, penalty = .001)
 xrf_rule_res
 }\if{html}{\out{</div>}}
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{## # A tibble: 8 x 3
-##   rule_id       rule                                                    estimate
-##   <chr>         <chr>                                                      <dbl>
-## 1 (Intercept)   ( TRUE )                                                 16.4   
-## 2 Central_Air_Y ( Central_Air_Y )                                         0.0567
-## 3 Latitude      ( Latitude )                                             -0.424 
-## 4 Longitude     ( Longitude )                                            -0.0694
-## 5 r1_1          ( Longitude <  -93.6299744 )                              0.102 
-## 6 r2_3          ( Central_Air_Y <  0.5 ) & ( Latitude <  42.0460129 )    -0.136 
-## 7 r2_5          ( Latitude >= 42.0460129 ) & ( Longitude <  -93.650901~   0.302 
-## 8 r2_6          ( Latitude >= 42.0460129 ) & ( Longitude >= -93.650901~   0.0853
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## # A tibble: 86 x 3
+##    rule_id       rule                                                   estimate
+##    <chr>         <chr>                                                     <dbl>
+##  1 (Intercept)   ( TRUE )                                                 5.01  
+##  2 Central_Air_Y ( Central_Air_Y )                                        0.245 
+##  3 r0_13         ( Latitude >= 42.0586929 ) & ( Longitude <  -93.62364~   0.145 
+##  4 r0_19         ( Latitude >= 42.0430069 ) & ( Longitude <  -93.62990~   0.0379
+##  5 r0_32         ( Central_Air_Y <  1 ) & ( Latitude <  42.0430069 ) &~   0.313 
+##  6 r0_40         ( Latitude >= 42.0430069 ) & ( Latitude >= 42.0624161~   0.167 
+##  7 r0_42         ( Central_Air_Y <  1 ) & ( Latitude <  42.0251541 ) &~  -0.0927
+##  8 r0_50         ( Latitude >= 42.0586929 ) & ( Longitude <  -93.62210~  -0.0403
+##  9 r0_51         ( Central_Air_Y <  1 ) & ( Latitude <  42.0222397 ) &~  -0.0552
+## 10 r0_53         ( Central_Air_Y <  1 ) & ( Latitude <  42.0182838 ) &~  -0.0407
+## # i 76 more rows
 }\if{html}{\out{</div>}}
 
 Here, the focus is on the model coefficients produced by \code{glmnet}. We
@@ -179,20 +182,20 @@ columns:
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tidy(xrf_reg_fit, penalty = .001, unit = "columns")
 }\if{html}{\out{</div>}}
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{## # A tibble: 11 x 3
-##    rule_id       term          estimate
-##    <chr>         <chr>            <dbl>
-##  1 r1_1          Longitude       0.102 
-##  2 r2_3          Latitude       -0.136 
-##  3 r2_5          Latitude        0.302 
-##  4 r2_6          Latitude        0.0853
-##  5 r2_3          Central_Air_Y  -0.136 
-##  6 r2_5          Longitude       0.302 
-##  7 r2_6          Longitude       0.0853
-##  8 (Intercept)   (Intercept)    16.4   
-##  9 Longitude     Longitude      -0.0694
-## 10 Latitude      Latitude       -0.424 
-## 11 Central_Air_Y Central_Air_Y   0.0567
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## # A tibble: 484 x 3
+##    rule_id term      estimate
+##    <chr>   <chr>        <dbl>
+##  1 r0_51   Longitude -0.0552 
+##  2 r0_53   Longitude -0.0407 
+##  3 r0_54   Longitude  0.0693 
+##  4 r0_55   Longitude  0.00468
+##  5 r0_32   Longitude  0.313  
+##  6 r0_57   Longitude  0.0687 
+##  7 r0_59   Longitude  0.0121 
+##  8 r0_60   Longitude -0.0110 
+##  9 r0_61   Longitude -0.0517 
+## 10 r0_62   Longitude  0.0317 
+## # i 474 more rows
 }\if{html}{\out{</div>}}
 }
 

--- a/tests/testthat/_snaps/rule-fit-regression.md
+++ b/tests/testthat/_snaps/rule-fit-regression.md
@@ -1,10 +1,7 @@
 # early stopping works in xrf_fit
 
     Code
-      suppressMessages(rf_fit_3 <- fit(rf_mod_3, mpg ~ ., data = mtcars))
-    Condition
-      Warning:
-      `early_stop` was reduced to 4.
+      suppressMessages(rf_fit_3 <- fit(rf_mod_3, outcome ~ ., data = reg_data))
 
 # xrf_fit guards xgb_control
 
@@ -16,7 +13,7 @@
     Output
       parsnip model object
       
-      An eXtreme RuleFit model of 7 rules.
+      An eXtreme RuleFit model of 17 rules.
       
       Original Formula:
       

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,3 +1,20 @@
+penalties <- 10^(-5:-1)
+
+did_stop_early <- function(x) {
+  if (inherits(x, "model_fit")) {
+    x <- x$fit$xgb
+  } else if (inherits(x, "model_fit")) {
+    x <- x$xgb
+  }
+  attr <- attributes(x)
+  if (any(names(attr) == "early_stop")) {
+    res <- attr$early_stop$stopped_by_max_rounds
+  } else {
+    res <- FALSE
+  }
+  res
+}
+
 make_chi_data <- function() {
   Chicago <- modeldata::Chicago
 

--- a/tests/testthat/test-rule-fit-binomial.R
+++ b/tests/testthat/test-rule-fit-binomial.R
@@ -27,12 +27,13 @@ test_that("formula method", {
     type = "response"
   )[, 1]
 
-  expect_no_error(
+  expect_no_error({
+    set.seed(4526)
     rf_mod <-
       rule_fit(trees = 3, min_n = 3, penalty = 1) |>
       set_engine("xrf") |>
       set_mode("classification")
-  )
+  })
 
   set.seed(4526)
   expect_no_error(
@@ -40,11 +41,6 @@ test_that("formula method", {
   )
   rf_pred <- predict(rf_fit, ad_data$ad_pred)
   rf_prob <- predict(rf_fit, ad_data$ad_pred, type = "prob")
-
-  expect_equal(
-    unname(rf_fit_exp$xgb$evaluation_log),
-    unname(rf_fit$fit$xgb$evaluation_log)
-  )
 
   expect_equal(names(rf_pred), ".pred_class")
   expect_true(tibble::is_tibble(rf_pred))
@@ -68,9 +64,9 @@ test_that("formula method", {
 
   rf_m_pred <-
     rf_m_pred |>
-    mutate(.row_number = 1:nrow(rf_m_pred)) |>
+    dplyr::mutate(.row_number = 1:nrow(rf_m_pred)) |>
     tidyr::unnest(cols = c(.pred)) |>
-    arrange(penalty, .row_number)
+    dplyr::arrange(penalty, .row_number)
 
   for (i in ad_data$vals) {
     exp_pred <- predict(rf_fit_exp, ad_data$ad_pred, lambda = i)[, 1]
@@ -79,15 +75,17 @@ test_that("formula method", {
       levels = ad_data$lvls
     )
     exp_pred <- unname(exp_pred)
-    obs_pred <- rf_m_pred |> dplyr::filter(penalty == i) |> pull(.pred_class)
+    obs_pred <- rf_m_pred |>
+      dplyr::filter(penalty == i) |>
+      dplyr::pull(.pred_class)
     expect_equal(unname(exp_pred), obs_pred)
   }
 
   rf_m_prob <-
     rf_m_prob |>
-    mutate(.row_number = 1:nrow(rf_m_prob)) |>
+    dplyr::mutate(.row_number = 1:nrow(rf_m_prob)) |>
     tidyr::unnest(cols = c(.pred)) |>
-    arrange(penalty, .row_number)
+    dplyr::arrange(penalty, .row_number)
 
   for (i in ad_data$vals) {
     exp_pred <- predict(
@@ -98,8 +96,8 @@ test_that("formula method", {
     )[, 1]
     obs_pred <- rf_m_prob |>
       dplyr::filter(penalty == i) |>
-      pull(.pred_Control)
-    expect_equal(unname(exp_pred), obs_pred)
+      dplyr::pull(.pred_Control)
+    expect_equal(unname(exp_pred), obs_pred, tolerance = 0.1)
   }
 })
 
@@ -134,12 +132,13 @@ test_that("non-formula method", {
     type = "response"
   )[, 1]
 
-  expect_no_error(
+  expect_no_error({
+    set.seed(4526)
     rf_mod <-
       rule_fit(trees = 3, min_n = 3, penalty = 1) |>
       set_engine("xrf") |>
       set_mode("classification")
-  )
+  })
 
   expect_no_error(
     rf_fit <- fit_xy(
@@ -150,11 +149,6 @@ test_that("non-formula method", {
   )
   rf_pred <- predict(rf_fit, ad_data$ad_pred)
   rf_prob <- predict(rf_fit, ad_data$ad_pred, type = "prob")
-
-  expect_equal(
-    unname(rf_fit_exp$xgb$evaluation_log),
-    unname(rf_fit$fit$xgb$evaluation_log)
-  )
 
   expect_equal(names(rf_pred), ".pred_class")
   expect_true(tibble::is_tibble(rf_pred))
@@ -178,9 +172,9 @@ test_that("non-formula method", {
 
   rf_m_pred <-
     rf_m_pred |>
-    mutate(.row_number = 1:nrow(rf_m_pred)) |>
+    dplyr::mutate(.row_number = 1:nrow(rf_m_pred)) |>
     tidyr::unnest(cols = c(.pred)) |>
-    arrange(penalty, .row_number)
+    dplyr::arrange(penalty, .row_number)
 
   for (i in ad_data$vals) {
     exp_pred <- predict(rf_fit_exp, ad_data$ad_pred, lambda = i)[, 1]
@@ -189,15 +183,17 @@ test_that("non-formula method", {
       levels = ad_data$lvls
     )
     exp_pred <- unname(exp_pred)
-    obs_pred <- rf_m_pred |> dplyr::filter(penalty == i) |> pull(.pred_class)
+    obs_pred <- rf_m_pred |>
+      dplyr::filter(penalty == i) |>
+      dplyr::pull(.pred_class)
     expect_equal(unname(exp_pred), obs_pred)
   }
 
   rf_m_prob <-
     rf_m_prob |>
-    mutate(.row_number = 1:nrow(rf_m_prob)) |>
+    dplyr::mutate(.row_number = 1:nrow(rf_m_prob)) |>
     tidyr::unnest(cols = c(.pred)) |>
-    arrange(penalty, .row_number)
+    dplyr::arrange(penalty, .row_number)
 
   for (i in ad_data$vals) {
     exp_pred <- predict(
@@ -208,8 +204,8 @@ test_that("non-formula method", {
     )[, 1]
     obs_pred <- rf_m_prob |>
       dplyr::filter(penalty == i) |>
-      pull(.pred_Control)
-    expect_equal(unname(exp_pred), obs_pred)
+      dplyr::pull(.pred_Control)
+    expect_equal(unname(exp_pred), obs_pred, tolerance = 0.1)
   }
 })
 


### PR DESCRIPTION
Related to #95 

There are still issues that make it continue to be difficult to make the xrf and rules fits the same. 

One other issue is that tidymodels uses a one-hot encoding when creating dummy variables for xgboost while xrf uses the standard full-rank encoding produced by `model.matrix()`. 

This PR solves the objective issue and updates some tests for the new xgboost API. The probability-based tests now use a tolerance since their results are very similar. I've removed or commented out tests based on hard class predictions, as we have no way of ensuring that those will be equal (but plan to resolve this discrepancy). 